### PR TITLE
Remove mistaken explicit refs to BlastN

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -122,7 +122,7 @@
                 </div>
             </div><!-- end panel body -->
         </fieldset>
-        <button class="btn btn-default form-submit"><span class="glyphicon glyphicon-ok"></span> Run BlastN</button>
+        <button class="btn btn-default form-submit"><span class="glyphicon glyphicon-ok"></span> Run Blast</button>
       </form>
     </div><!-- end div submit -->
     <div class="job-monitor hidden">

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -15,7 +15,7 @@
   
   //app template
   var BLAST_CONFIG = {
-        'name': 'blast-test-%DATESTAMP',
+        'name': 'blast-%DATESTAMP',
         'appId': 'ncbi-blastn-2.2.29u3',
         'queue': 'normal',
         'nodeCount': 1,
@@ -23,7 +23,7 @@
         'processorsPerNode': 1,
         'requestedTime': '00:30:00',
         'archive': true,
-        'archivePath': '%USERNAME/archive/jobs/blastn-test-%DATESTAMP',
+        'archivePath': '%USERNAME/archive/jobs/blast-%DATESTAMP',
         'archiveSystem': 'araport-storage-00',
         /*
         'notifications': [{
@@ -217,7 +217,7 @@
         //get blast type and add to app instance
         BlastApp.blastType = $('#appId').val();
         BLAST_CONFIG.appId = blastTypes[BlastApp.blastType];
-        BlastApp.outputFile = BlastApp.username + '/archive/jobs/blastn-test-'+ BlastApp.now + '/' + BlastApp.blastType + '_out';
+        BlastApp.outputFile = BlastApp.username + '/archive/jobs/blast-'+ BlastApp.now + '/' + BlastApp.blastType + '_out';
         
         //get databases and add to app instance
         var dbs = '';


### PR DESCRIPTION
Since the generic term for the app is blast, changed the Run button to
“Run BLAST” and the output directories to blast-DATE
